### PR TITLE
chore: Change JWT storage from cookie to localStorage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+OpenSesame Frontend is a React-based user management and authentication interface that connects to the opensesame-back API. It provides role-based access control with user, admin roles and permission-based actions.
+
+## Development Commands
+
+```bash
+# Development server (runs on port 3000)
+yarn start
+
+# Production build
+yarn build
+
+# Run all tests
+yarn test
+
+# Lint and fix code
+yarn lint
+
+# Format code with Prettier
+yarn prettify
+
+# TypeScript type checking
+yarn types
+
+# Complete verification pipeline (lint, format, types, audit, test, build)
+yarn verify
+
+# Security scan with gitleaks
+yarn gitleaks
+```
+
+## Architecture Overview
+
+### Core Structure
+- **React Router v7** with lazy loading for all routes
+- **Context-based state management** using UserContext and ToastContext
+- **Axios-based API client** with cookie-based authentication
+- **TypeScript** throughout with strict type checking
+- **Webpack** custom configuration for bundling
+- **Jest + Testing Library** for testing with MSW for API mocking
+
+### Key Directories
+- `src/pages/` - Main application pages (Login, MainPage, ManageUsers, NewUser)
+- `src/components/` - Reusable UI components with co-located tests and types
+- `src/context/` - React contexts for global state (User, Toast)
+- `src/common/types/` - TypeScript type definitions
+- `src/mocks/` - MSW handlers and mock data for testing
+- `src/api.ts` - Axios instance configuration
+
+### Authentication Flow
+- Cookie-based authentication with `withCredentials: true`
+- Protected routes wrapped with ProtectedRoute component
+- User state managed through UserContext
+- BASE_URL_API environment variable for API endpoint configuration
+
+### Component Organization
+Each component follows a consistent pattern:
+- Component.tsx (main component)
+- Component.test.tsx (tests)
+- Component.types.ts (TypeScript interfaces)
+- Co-located with related sub-components
+
+### State Management
+- UserContext: Manages logged-in user data and authentication state
+- ToastContext: Handles application-wide notifications and status messages
+- No external state management library (Redux, Zustand) - uses React Context
+
+### Testing Strategy
+- Jest with jsdom environment
+- React Testing Library for component testing
+- MSW (Mock Service Worker) for API mocking
+- Test setup includes polyfills and custom matchers
+- Tests co-located with components
+
+## Environment Configuration
+
+Create `.env` from `.example.env`:
+```bash
+NODE_ENV=development
+BASE_URL_API=http://localhost:8080/api
+```
+
+## Type System
+
+The app uses strict TypeScript with:
+- User types defining roles ('user' | 'admin') and permissions
+- API response types for backend integration
+- Component prop types for all interfaces
+- Strict null checks enabled
+
+## Important Notes
+
+- Requires opensesame-back API running on configured BASE_URL_API
+- Uses React 19 with modern React Router v7
+- Webpack dev server includes history API fallback for client-side routing
+- ESLint configuration includes React, TypeScript, accessibility, and testing rules
+- Import sorting is enforced with specific grouping rules (React imports first)

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,23 @@
 import axios, { AxiosInstance } from 'axios';
 
+import { getToken } from './utils/tokenStorage';
+
 const api: AxiosInstance = axios.create({
-  baseURL: process.env.BASE_URL_API,
-  withCredentials: true // Ensures cookies are included in requests
+  baseURL: process.env.BASE_URL_API
 });
+
+// Request interceptor to add Authorization header with Bearer token
+api.interceptors.request.use(
+  (config) => {
+    const token = getToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
 
 export default api;

--- a/src/components/Navbar/Navbar.test.tsx
+++ b/src/components/Navbar/Navbar.test.tsx
@@ -13,11 +13,11 @@ jest.mock('../../context/UserContext/UserContext');
 jest.mock('../../api');
 
 describe('Navbar', () => {
-  const mockSetUser = jest.fn();
+  const mockLogout = jest.fn();
   (api.delete as jest.Mock).mockResolvedValue({});
 
   beforeEach(() => {
-    (useUser as jest.Mock).mockReturnValue({ setUser: mockSetUser });
+    (useUser as jest.Mock).mockReturnValue({ logout: mockLogout });
     (api.delete as jest.Mock).mockResolvedValue({});
   });
 
@@ -45,6 +45,6 @@ describe('Navbar', () => {
     await waitFor(() => {
       expect(api.delete).toHaveBeenCalledWith('/v1/users/logout');
     });
-    expect(mockSetUser).toHaveBeenCalledWith(null);
+    expect(mockLogout).toHaveBeenCalled();
   });
 });

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -11,11 +11,11 @@ import { useUser } from '../../context/UserContext/UserContext';
  */
 const Navbar = () => {
   const navigate = useNavigate();
-  const { setUser } = useUser();
+  const { logout } = useUser();
 
   const handleLogout = async () => {
     await api.delete('/v1/users/logout');
-    setUser(null);
+    logout();
     navigate('/login');
   };
 

--- a/src/context/UserContext/UserContext.tsx
+++ b/src/context/UserContext/UserContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState } from 'react';
 
 import { User } from '../../common/types/User.types';
+import { removeToken, setToken } from '../../utils/tokenStorage';
 
 import { UserContextType, UserProviderProps } from './UserContext.types';
 
@@ -16,7 +17,19 @@ const UserContext = createContext<UserContextType | undefined>(undefined);
 export const UserProvider = ({ children }: UserProviderProps) => {
   const [user, setUser] = useState<User | null>(null);
 
-  return <UserContext.Provider value={{ user, setUser }}>{children}</UserContext.Provider>;
+  const login = (userData: User, token: string) => {
+    setToken(token);
+    setUser(userData);
+  };
+
+  const logout = () => {
+    removeToken();
+    setUser(null);
+  };
+
+  return (
+    <UserContext.Provider value={{ user, setUser, login, logout }}>{children}</UserContext.Provider>
+  );
 };
 
 /**

--- a/src/context/UserContext/UserContext.types.ts
+++ b/src/context/UserContext/UserContext.types.ts
@@ -3,6 +3,8 @@ import { User } from '../../common/types/User.types';
 export type UserContextType = {
   user: User | null;
   setUser: (user: User | null) => void;
+  login: (user: User, token: string) => void;
+  logout: () => void;
 };
 
 export type UserProviderProps = {

--- a/src/mocks/msw/handlers/handlers.ts
+++ b/src/mocks/msw/handlers/handlers.ts
@@ -18,7 +18,11 @@ export const handlers = [
     if (email === 'test@example.com' && password === 'password123') {
       return res(
         ctx.status(200),
-        ctx.json({ data: { user: { id: 1, name: 'Test User', email } } })
+        ctx.json({
+          status: 'success',
+          token: 'mock-jwt-token',
+          data: { user: { id: 1, name: 'Test User', email } }
+        })
       );
     }
     return res(ctx.status(401), ctx.json({ message: 'Invalid credentials' }));

--- a/src/pages/Login/Login.test.tsx
+++ b/src/pages/Login/Login.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 
 import Login from './Login';
 
-const mockSetUser = jest.fn(); // Mock the setUser function
+const mockLogin = jest.fn(); // Mock the login function
 jest.mock('../../context/UserContext/UserContext', () => ({
   user: {
     name: 'John Doe',
@@ -14,7 +14,7 @@ jest.mock('../../context/UserContext/UserContext', () => ({
     role: 'admin'
   },
   useUser: () => ({
-    setUser: mockSetUser
+    login: mockLogin
   })
 }));
 
@@ -50,14 +50,17 @@ describe('Login', () => {
     // Simulate form submission by clicking the login button
     await userEvent.click(submitButton);
 
-    // Wait for the success response and assert that setUser and navigate are called
+    // Wait for the success response and assert that login and navigate are called
     await waitFor(() => {
-      // Check if setUser was called with the correct user data
-      expect(mockSetUser).toHaveBeenCalledWith({
-        id: 1,
-        name: 'Test User',
-        email: 'test@example.com'
-      });
+      // Check if login was called with the correct user data and token
+      expect(mockLogin).toHaveBeenCalledWith(
+        {
+          id: 1,
+          name: 'Test User',
+          email: 'test@example.com'
+        },
+        'mock-jwt-token'
+      );
     });
   });
 

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -6,14 +6,14 @@ import api from '../../api';
 import { useUser } from '../../context/UserContext/UserContext';
 
 /**
- * Login page. User can login with email and password. This sets the user in the UserContext and a JWT token on a cookie.
+ * Login page. User can login with email and password. This sets the user in the UserContext and a JWT token in localStorage.
  * Redirects to the main page after successful login, or stays on the login page if the login fails.
  * If the user is already logged in, redirects to the main page.
  *
  * @returns {JSX.Element} Login component
  */
 function Login() {
-  const { setUser } = useUser();
+  const { login } = useUser();
 
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
@@ -47,7 +47,7 @@ function Login() {
     try {
       const response = await api.post('/v1/users/login', { email, password });
       if (response.status === 200) {
-        setUser(response.data.data.user);
+        login(response.data.data.user, response.data.token);
         navigate('/mainpage'); // Redirect to the main page after login
       }
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,0 +1,36 @@
+/**
+ * Utility functions for managing JWT tokens in localStorage
+ */
+
+const TOKEN_KEY = 'opensesame_session';
+
+/**
+ * Store JWT token in localStorage
+ * @param token - JWT token string
+ */
+export const setToken = (token: string): void => {
+  localStorage.setItem(TOKEN_KEY, token);
+};
+
+/**
+ * Retrieve JWT token from localStorage
+ * @returns JWT token string or null if not found
+ */
+export const getToken = (): string | null => {
+  return localStorage.getItem(TOKEN_KEY);
+};
+
+/**
+ * Remove JWT token from localStorage
+ */
+export const removeToken = (): void => {
+  localStorage.removeItem(TOKEN_KEY);
+};
+
+/**
+ * Check if user has a valid token stored
+ * @returns boolean indicating if token exists
+ */
+export const hasToken = (): boolean => {
+  return getToken() !== null;
+};


### PR DESCRIPTION
### What's new

- Now the JWT auth token instead of being stored on a cookie it's stored on localStorage.

### What's fixed

Nothing fixed here...

### How to test

- `yarn test`
- Start it and try to login

### Breaking changes

- JWT is now stored on localStorage instead of cookie

### Checklist

- [x] I've tested locally the changes
- [x] I've run `yarn verify` to perform basic checks and lints
- [x] I've run `gitleaks` to check for hardcoded secrets and tokens
